### PR TITLE
Allows Code to receive custom prefill properties

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -17,7 +17,7 @@ function App() {
   return (
     <div className="App">
       <Book className="Box Left" />
-      <Code {...prefill} className="Box Right" />
+      <Code title="" {...prefill} className="Box Right" />
     </div>
   )
 }

--- a/src/App.js
+++ b/src/App.js
@@ -3,11 +3,21 @@ import "./App.css"
 import Book from "./Book"
 import Code from "./Code"
 
+const prefill = {
+  html: `
+<p>
+hello, world!
+</p>
+`,
+  css: `body {background-color: #F1B8FF};`,
+  js: `console.log('press F12 to see this');`,
+}
+
 function App() {
   return (
     <div className="App">
       <Book className="Box Left" />
-      <Code className="Box Right" />
+      <Code {...prefill} className="Box Right" />
     </div>
   )
 }

--- a/src/App.js
+++ b/src/App.js
@@ -4,13 +4,9 @@ import Book from "./Book"
 import Code from "./Code"
 
 const prefill = {
-  html: `
-<p>
-hello, world!
-</p>
-`,
+  html: true,
   css: `body {background-color: #F1B8FF};`,
-  js: `console.log('press F12 to see this');`,
+  js: true,
 }
 
 function App() {

--- a/src/Book.js
+++ b/src/Book.js
@@ -2,7 +2,7 @@ import React from "react"
 import "./Book.css"
 
 function Book({ className }) {
-  return <div className={`Book ${className}`}>book</div>
+  return <div className={`Book ${className ? className : ""}`}>book</div>
 }
 
 export default Book

--- a/src/Code.js
+++ b/src/Code.js
@@ -1,16 +1,17 @@
 import React from "react"
 import "./Code.css"
 
-function Code({ html, css, js, className }) {
+function Code({ title, html, css, js, className }) {
   return (
-    <div className={`Code ${className}`}>
+    <div className={`Code ${className ? className : ""}`}>
       <div
+        title="codepen"
         className="codepen"
         data-height="100%"
         data-editable="true"
         data-theme-id="dark"
         data-default-tab="html,result"
-        data-prefill='{"title":"Demo"}'
+        data-prefill={`{"title":"${title ? title : ""}"}`}
       >
         <pre data-lang="html">{html}</pre>
         <pre data-lang="css">{css}</pre>

--- a/src/Code.js
+++ b/src/Code.js
@@ -1,7 +1,7 @@
 import React from "react"
 import "./Code.css"
 
-function Code({ className }) {
+function Code({ html, css, js, className }) {
   return (
     <div className={`Code ${className}`}>
       <div
@@ -12,9 +12,9 @@ function Code({ className }) {
         data-default-tab="html,result"
         data-prefill='{"title":"Demo"}'
       >
-        <pre data-lang="html">{"test"}</pre>
-        <pre data-lang="css">{"body {background-color: #F1B8FF;}"}</pre>
-        <pre data-lang="js">{"console.log('press F12 to see this')"}</pre>
+        <pre data-lang="html">{html}</pre>
+        <pre data-lang="css">{css}</pre>
+        <pre data-lang="js">{js}</pre>
       </div>
     </div>
   )

--- a/src/Code.js
+++ b/src/Code.js
@@ -1,7 +1,23 @@
 import React from "react"
 import "./Code.css"
 
+const DEFAULT = {
+  html: `<body>
+
+</body>`,
+  css: `body {
+  
+};
+`,
+  js: `// Aperte F12 para acessar o Console
+`,
+}
+
 function Code({ title, html, css, js, className }) {
+  if (html === true) html = DEFAULT.html
+  if (css === true) css = DEFAULT.css
+  if (js === true) js = DEFAULT.js
+
   return (
     <div className={`Code ${className ? className : ""}`}>
       <div

--- a/src/Code.test.js
+++ b/src/Code.test.js
@@ -3,7 +3,7 @@ import { render } from "@testing-library/react"
 import Code from "./Code"
 
 test("renders Code box", () => {
-  const { container, debug } = render(<Code className="Box Test" />)
+  const { container } = render(<Code className="Box Test" />)
 
   const code = container.firstChild
   expect(code).toBeInTheDocument()
@@ -16,19 +16,43 @@ test("renders CodePen", () => {
   const codepen = getByTitle("codepen")
   expect(codepen).toBeInTheDocument()
   expect(codepen).toHaveAttribute("data-prefill", `{"title":""}`)
+  expect(codepen).not.toHaveTextContent()
 })
 
 test("renders CodePen with title", () => {
   const title = "hello"
 
-  const { getByTitle } = render(<Code title="hello" />)
+  const { getByTitle } = render(<Code title="Hello, World!" />)
 
   const codepen = getByTitle("codepen")
   expect(codepen).toBeInTheDocument()
-  expect(codepen).toHaveAttribute("data-prefill", `{"title":"hello"}`)
+  expect(codepen).toHaveAttribute("data-prefill", `{"title":"Hello, World!"}`)
+  expect(codepen).not.toHaveTextContent()
 })
 
-test("renders CodePen with prefill", () => {
+test("renders CodePen with default prefill for html, css and js", () => {
+  const prefill = {
+    html: true,
+    css: true,
+    js: true,
+  }
+
+  const { getByText } = render(<Code {...prefill} />)
+
+  const html = getByText((content) => content.startsWith("<body>"))
+  expect(html).toBeInTheDocument()
+  expect(html).toHaveAttribute("data-lang", "html")
+
+  const css = getByText((content) => content.startsWith("body"))
+  expect(css).toBeInTheDocument()
+  expect(css).toHaveAttribute("data-lang", "css")
+
+  const js = getByText((content) => content.startsWith("//"))
+  expect(js).toBeInTheDocument()
+  expect(js).toHaveAttribute("data-lang", "js")
+})
+
+test("renders CodePen with provided prefill for html, css and js", () => {
   const prefill = {
     html: `<div>welcome</div>`,
     css: `div {color: purple}`,

--- a/src/Code.test.js
+++ b/src/Code.test.js
@@ -3,9 +3,32 @@ import { render } from "@testing-library/react"
 import Code from "./Code"
 
 test("renders Code box", () => {
-  const { container } = render(<Code className="Box Test" />)
+  const { container, debug } = render(<Code className="Box Test" />)
 
   const code = container.firstChild
   expect(code).toBeInTheDocument()
   expect(code).toHaveClass("Code", "Box", "Test")
+  debug()
+})
+
+test("renders Code box with prefill", () => {
+  const prefill = {
+    html: `<div>welcome</div>`,
+    css: `div {color: purple}`,
+    js: `alert('hello')`,
+  }
+
+  const { getByText } = render(<Code {...prefill} />)
+
+  const html = getByText(prefill.html)
+  expect(html).toBeInTheDocument()
+  expect(html).toHaveAttribute("data-lang", "html")
+
+  const css = getByText(prefill.css)
+  expect(css).toBeInTheDocument()
+  expect(css).toHaveAttribute("data-lang", "css")
+
+  const js = getByText(prefill.js)
+  expect(js).toBeInTheDocument()
+  expect(js).toHaveAttribute("data-lang", "js")
 })

--- a/src/Code.test.js
+++ b/src/Code.test.js
@@ -8,10 +8,27 @@ test("renders Code box", () => {
   const code = container.firstChild
   expect(code).toBeInTheDocument()
   expect(code).toHaveClass("Code", "Box", "Test")
-  debug()
 })
 
-test("renders Code box with prefill", () => {
+test("renders CodePen", () => {
+  const { getByTitle } = render(<Code />)
+
+  const codepen = getByTitle("codepen")
+  expect(codepen).toBeInTheDocument()
+  expect(codepen).toHaveAttribute("data-prefill", `{"title":""}`)
+})
+
+test("renders CodePen with title", () => {
+  const title = "hello"
+
+  const { getByTitle } = render(<Code title="hello" />)
+
+  const codepen = getByTitle("codepen")
+  expect(codepen).toBeInTheDocument()
+  expect(codepen).toHaveAttribute("data-prefill", `{"title":"hello"}`)
+})
+
+test("renders CodePen with prefill", () => {
   const prefill = {
     html: `<div>welcome</div>`,
     css: `div {color: purple}`,


### PR DESCRIPTION
This PR allows the `Code` component to receive custom props:

- `title`: sets CodePen project title (defaults to "Untitled")
- `html`, `css`, `js`: sets CodePen HTML, CSS and JS string contents 
(accepts `true` to display the default contents and `false`y values to hide the tab)